### PR TITLE
Fix permission request for notifications in EmarsysAppDelegate

### DIFF
--- a/ios/Classes/EmarsysAppDelegate.swift
+++ b/ios/Classes/EmarsysAppDelegate.swift
@@ -6,13 +6,18 @@ import EmarsysSDK
 @objc open class EmarsysAppDelegate: FlutterAppDelegate {
   
     open override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        application.registerForRemoteNotifications()
         var authorizationOptions: UNAuthorizationOptions = [.sound, .alert, .badge]
         if #available(iOS 12.0, *) {
             authorizationOptions = [.sound, .alert, .badge, .provisional]
         }
-        UNUserNotificationCenter.current().requestAuthorization(options: authorizationOptions) { granted, error in
-        }
+        UNUserNotificationCenter.current().requestAuthorization(options: authorizationOptions,
+                    completionHandler: {(granted, error) in
+                        if granted {
+                            DispatchQueue.main.async() {
+                                UIApplication.shared.registerForRemoteNotifications()
+                            }
+                        }
+                    });
         UNUserNotificationCenter.current().delegate = UserNotificationCenterDelegateCacher.instance
         
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)


### PR DESCRIPTION

The iOS device gets registered in the emarsys backend because of the application.registerForRemoteNotifications().
But the call of the requestAuthorization() does not work and so the user doesn't get a permission request for push notifications. So the app gets notifications this way but only silent. With the change the user gets a permission request for push notifications on the first start of the app.
