### PR TITLE
Remove JVM Toolchain Specification for Better M1 Compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,9 +51,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlin {
-        jvmToolchain(17)
-    }
+
 }
 
 


### PR DESCRIPTION
## Overview
This pull request addresses compatibility issues observed when running the application on Mac M1 devices. The M1 chips, based on ARM architecture, have been noted to face compatibility challenges with certain Java toolchain configurations. To be more specific, the build actually fails when incorporating the emarsys sdk on M1 devices when used with other packages which have conflicting build.gradle files. This means projects which contain packages which have not been updated recently cannot build on android. The changes fix this.

## Changes
- Removed `kotlin { jvmToolchain(17) }` from build.gradle.

## Justification
The specified JVM toolchain version (Java 8) in Kotlin settings was causing issues on Mac M1 devices. This change aims to allow the Kotlin compiler to default to a toolchain that's more compatible with ARM architecture, potentially using a more recent JVM version. Testing indicated that removing this line resolves the issues without adversely affecting other functionalities.

## Impact
This change should enhance the app's performance and compatibility on M1 devices, ensuring a more seamless experience across different architectures.

## Additional Notes
Further testing might be required to ensure that this change doesn't impact other parts of the application, especially those relying on  jvmToolchain 17 specific features.