### PR TITLE
fix isEmarsysNotification check

### DIFF
--- a/ios/Classes/Wrapper/Push/UserNotificationCenterDelegateCacher.swift
+++ b/ios/Classes/Wrapper/Push/UserNotificationCenterDelegateCacher.swift
@@ -116,7 +116,7 @@ public class UserNotificationCenterDelegateCacher: NSObject, UNUserNotificationC
     }
     
     private func isEmarsysNotification(notification: UNNotification?) -> Bool {
-        return ((notification?.request.content.userInfo.contains(where: { $0.key as! String == "ems"})) != nil)
+        return notification?.request.content.userInfo.contains(where: { ($0.key as? String) == "ems" }) ?? false
     }
     
 }


### PR DESCRIPTION
Hey,
we use the emarsys flutter package since a few years in our flutter app.
Now we also want to be able to create local notifications via [flutter_local_notifications](https://pub.dev/packages/flutter_local_notifications).
While setting the new package up, we discovered that the onDidReceiveNotificationResponse-Callback of flutter_local_notifications does not work when we use EmarsysAppDelegate as super-class of our AppDelegate on iOS.
After some investigation we found out that the problem seems to be the isEmarsysNotification methode in your UserNotificationCenterDelegateCacher.swift.
The notification is not passed through the other notification delegates which were added via overriding notificationCenterDelegateDataSource().

In detail:
An example for an notification pushed by flutter_local_notifications:
<img width="410" height="189" alt="CleanShot 2025-07-30 at 14 56 55" src="https://github.com/user-attachments/assets/c4b298fe-0c7e-449c-a67e-ed097467f550" />
There is no "ems" key in the userInfo of the notification but the current implementation of isEmarsysNotification returns true so your delegate is used and not the custom ones.
(notification?.request.content.userInfo.contains(where: { $0.key as! String == "ems"})) -> is false but it not nil so true is returned. The != nil check is the problem.
See the code for a fix.

Would be awesome if you could check.