### PR TITLE
Fix issues with pushEventStream

### DIFF
--- a/android/src/main/kotlin/com/emarsys/emarsys_sdk/api/EmarsysFirebaseMessagingService.kt
+++ b/android/src/main/kotlin/com/emarsys/emarsys_sdk/api/EmarsysFirebaseMessagingService.kt
@@ -11,9 +11,11 @@ import com.emarsys.emarsys_sdk.di.dependencyContainerIsSetup
 import com.emarsys.emarsys_sdk.di.setupDependencyContainer
 import com.emarsys.emarsys_sdk.flutter.FlutterBackgroundExecutor
 import com.emarsys.emarsys_sdk.provider.MainHandlerProvider
+import com.emarsys.emarsys_sdk.util.JsonUtils
 import com.emarsys.service.EmarsysFirebaseMessagingServiceUtils
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import org.json.JSONObject
 import java.util.*
 
 class EmarsysFirebaseMessagingService : FirebaseMessagingService() {
@@ -41,6 +43,20 @@ class EmarsysFirebaseMessagingService : FirebaseMessagingService() {
             synchronized(messageQueue) {
                 messageQueue.forEach {
                     EmarsysFirebaseMessagingServiceUtils.handleMessage(context, it)
+                    
+                    if (dependencyContainerIsSetup()) {
+                        try {
+                            val payload = JSONObject()
+                            it.data.forEach { (key, value) ->
+                                payload.put(key, value)
+                            }
+                            dependencyContainer().uiHandler.post {
+                                dependencyContainer().pushEventHandler.handleEvent(context, "push", payload)
+                            }
+                        } catch (e: Exception) {
+                            e.printStackTrace()
+                        }
+                    }
                 }
                 messageQueue.clear()
             }

--- a/ios/Classes/Flutter/EmarsysSdkPlugin.swift
+++ b/ios/Classes/Flutter/EmarsysSdkPlugin.swift
@@ -17,6 +17,9 @@ public class EmarsysSdkPlugin: NSObject, FlutterPlugin {
         let geofenceHandler = EmarsysStreamHandler()
         let inAppHandler = EmarsysStreamHandler()
         
+        // Manual fallback for push events
+        UserNotificationCenterDelegateCacher.instance.manualPushEventHandler = pushHandler.eventHandler
+        
         NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "EmarsysSDKWrapperCheckerNotification"), object: nil, queue: nil) { (notification) in
             NotificationCenter.default.post(name: NSNotification.Name(rawValue: "EmarsysSDKWrapperExist"), object: "flutter")
         }
@@ -43,7 +46,7 @@ public class EmarsysSdkPlugin: NSObject, FlutterPlugin {
         registrar.register(inlineInappViewFactory, withId: "inlineInAppView")
     }
     
-    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {     
         guard let command = EmarsysSdkPlugin.factory?.create(name: call.method) else {
             let flutterError = FlutterError(code: "1501", message: "Command creation failed", details: nil)
             result(flutterError)

--- a/ios/Classes/Wrapper/Push/UserNotificationCenterDelegateCacher.swift
+++ b/ios/Classes/Wrapper/Push/UserNotificationCenterDelegateCacher.swift
@@ -10,6 +10,8 @@ public class UserNotificationCenterDelegateCacher: NSObject, UNUserNotificationC
     private var emarsysNotificationCenterDelegate: UNUserNotificationCenterDelegate?
     private var caching = true
     
+    public var manualPushEventHandler: ((String, [String: Any]?) -> Void)?
+    
     public static let instance = UserNotificationCenterDelegateCacher()
     
     public func userNotificationCenter(
@@ -22,10 +24,14 @@ public class UserNotificationCenterDelegateCacher: NSObject, UNUserNotificationC
                 "response": response,
                 "completionHandler": completionHandler,
             ])
-        }
+        }     
         if isEmarsysNotification(notification: response.notification) {
             emarsysNotificationCenterDelegate?.userNotificationCenter?(
                 center, didReceive: response, withCompletionHandler: completionHandler)
+            // Manual fallback for Flutter event
+            if let manualHandler = manualPushEventHandler {
+                manualHandler("push", response.notification.request.content.userInfo as? [String: Any])
+            }
         } else {
             customDelegates.forEach { delegate in
                 delegate.userNotificationCenter?(
@@ -48,6 +54,10 @@ public class UserNotificationCenterDelegateCacher: NSObject, UNUserNotificationC
         if isEmarsysNotification(notification: notification) {
             emarsysNotificationCenterDelegate?.userNotificationCenter?(
                 center, willPresent: notification, withCompletionHandler: completionHandler)
+            // Manual fallback for Flutter event
+            if let manualHandler = manualPushEventHandler {
+                manualHandler("push", notification.request.content.userInfo as? [String: Any])
+            }
         } else {
             customDelegates.forEach { delegate in
                 delegate.userNotificationCenter?(
@@ -85,14 +95,14 @@ public class UserNotificationCenterDelegateCacher: NSObject, UNUserNotificationC
     }
     
     func emptyCache(with notificationCenterDelegate: UNUserNotificationCenterDelegate) {
-        self.emarsysNotificationCenterDelegate = notificationCenterDelegate
+        self.emarsysNotificationCenterDelegate = notificationCenterDelegate        
         willPresentCache.forEach { cachedDict in
             notificationCenterDelegate.userNotificationCenter?(
                 cachedDict["center"] as! UNUserNotificationCenter,
                 willPresent: cachedDict["notification"] as! UNNotification,
                 withCompletionHandler: cachedDict["completionHandler"]
                 as! (UNNotificationPresentationOptions) -> Void)
-        }
+        }        
         didReceiveCache.forEach { cachedDict in
             notificationCenterDelegate.userNotificationCenter?(
                 cachedDict["center"] as! UNUserNotificationCenter,


### PR DESCRIPTION
Since there is no Issues tab in this project, I want to show this Pull Request to draw attention to a problem we had with Emarsys Flutter Plugin: pushEventStream did not receive any push messages. The solution might seem hacky. Feel free to fix this problem in another way. But receiving pushEventStream events from native part is for our use case crucial and was not working before.

**Android Changes**
_Files Modified_
- android/src/main/kotlin/com/emarsys/emarsys_sdk/event/EventHandlerFactory.kt
- android/src/main/kotlin/com/emarsys/emarsys_sdk/ui/InlineInAppView.kt
- android/src/main/kotlin/com/emarsys/emarsys_sdk/util/JsonUtils.kt (Local usage removed)

_The Problem_
The plugin previously used a local helper class (com.emarsys.emarsys_sdk.util.JsonUtils) to convert JSONObject push payloads into a Map for the Flutter EventChannel.

When a JSONObject contains a null value, it stores it as JSONObject.NULL (a specific object instance) rather than a standard Java null. Flutter's StandardMessageCodec cannot serialize JSONObject.NULL, leading to an IllegalArgumentException on the native side. This caused the plugin to silently drop events before they reached the Dart layer.

_The Fix_
Standardized JSON Handling: Switched imports in EventHandlerFactory.kt and InlineInAppView.kt to use the official com.emarsys.core.util.JsonUtils provided by the Emarsys SDK.

Null Safety: The SDK utility correctly handles JSONObject.NULL by converting it to a standard Java null, ensuring successful serialization to Flutter.

Robust Forwarding: Updated EmarsysFirebaseMessagingService.kt to more reliably queue and forward events.

**iOS Changes**
_Files Modified_

- ios/Classes/Flutter/EmarsysSdkPlugin.swift
- ios/Classes/Wrapper/Push/UserNotificationCenterDelegateCacher.swift

_The Problem_
The standard delegate chain (EmarsysNotificationCenterDelegate) occasionally failed to notify the Flutter plugin of incoming pushes. This was likely due to race conditions or delegate conflicts occurring during the early stages of app initialization.

_The Fix_
Implemented a manual fallback mechanism within the UserNotificationCenterDelegateCacher:

Direct Closure: Added a manualPushEventHandler closure to the Cacher.

Plugin Registration: Connected the EmarsysSdkPlugin push event handler directly to this closure upon registration.

Short-circuiting: The Cacher now explicitly checks for Emarsys notifications and invokes this manual handler immediately, bypassing potential delegate chain conflicts.